### PR TITLE
Increase network threshold cap for network client simplification

### DIFF
--- a/src/utils/imageProcessor.test.ts
+++ b/src/utils/imageProcessor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { scaleToMaxDimension } from './imageProcessor';
+import { scaleToMaxDimension, simplifyForNetworkClients, DEFAULT_PARAMS } from './imageProcessor';
 import { Image, createCanvas } from 'canvas';
 
 // Polyfill global Image and document for the scaling helper
@@ -41,5 +41,14 @@ describe('scaleToMaxDimension', () => {
 
     const scaled = await scaleToMaxDimension(dataUrl, 1000);
     expect(scaled).toBe(dataUrl);
+  });
+});
+
+describe('simplifyForNetworkClients', () => {
+  test('increases threshold with upper bound enforcement', () => {
+    const params = { ...DEFAULT_PARAMS, threshold: 128 };
+    const result = simplifyForNetworkClients(params);
+    expect(result.threshold).toBe(210); // 180 from complex + 30, capped below 255
+    expect(result.threshold).toBeLessThanOrEqual(255);
   });
 });

--- a/src/utils/imageProcessor.ts
+++ b/src/utils/imageProcessor.ts
@@ -492,9 +492,10 @@ export const simplifyForNetworkClients = (params: TracingParams): TracingParams 
   
   // Start with complex image optimizations
   const complexParams = simplifyForComplexImages(networkParams);
-  
+
   // Then apply even more aggressive settings
-  complexParams.threshold = Math.min(160, complexParams.threshold + 30);
+  // Increase threshold while capping at an upper bound to maintain contrast
+  complexParams.threshold = Math.min(255, complexParams.threshold + 30);
   complexParams.turdSize = Math.max(15, complexParams.turdSize * 2);  // More aggressive noise filtering
   complexParams.alphaMax = Math.min(0.5, complexParams.alphaMax - 0.1);
   complexParams.optCurve = false; // Disable curve optimization to speed up processing


### PR DESCRIPTION
## Summary
- Raise network client threshold cap to maintain contrast up to 255
- Add test verifying threshold increase and bounds in `simplifyForNetworkClients`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any & no-var issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c48ec54a88832396741a530d091273