### PR TITLE
feat: consolidate image resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ A desktop application that converts raster images to SVG using Potrace.
 The application follows these steps to convert raster images to SVG:
 
 1. **Image Loading**: Uploads and loads the source image into memory
-2. **Preprocessing**: 
-   - Scales large images down to a maximum of 1000px on the longest side while preserving aspect ratio (`scaleToMaxDimension`)
-   - Draws the image to a canvas with a white background
+2. **Preprocessing**:
+   - Scales large images down to a maximum of 1000px on the longest side while preserving aspect ratio (`resizeImage`)
+   - Draws the image to a canvas with an optional background color
 
 3. **Grayscale Conversion**:
    - Processes each pixel using the luminance formula: `0.299*R + 0.587*G + 0.114*B`
@@ -263,7 +263,7 @@ npm run build
 
 ## Known Limitations
 
-- Large images are automatically scaled down to 1000px maximum dimension (`scaleToMaxDimension`)
+- Large images are automatically scaled down to 1000px maximum dimension (`resizeImage`)
 - Works best with high-contrast images
 - Processing may take some time depending on image complexity
 

--- a/src/utils/imageProcessor.test.ts
+++ b/src/utils/imageProcessor.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest';
-import { scaleToMaxDimension } from './imageProcessor';
+import { resizeImage } from './imageProcessor';
 import { Image, createCanvas } from 'canvas';
 
-// Polyfill global Image and document for the scaling helper
+// Polyfill global Image and document for the resizing helper
 (global as any).Image = Image;
 (global as any).document = {
   createElement: (name: string) => {
@@ -13,15 +13,15 @@ import { Image, createCanvas } from 'canvas';
   }
 };
 
-describe('scaleToMaxDimension', () => {
-  test('scales images larger than 1000px', async () => {
+describe('resizeImage', () => {
+  test('scales images larger than max dimension', async () => {
     const canvas = createCanvas(2000, 500);
     const ctx = canvas.getContext('2d');
     ctx.fillStyle = '#000';
     ctx.fillRect(0, 0, 2000, 500);
     const dataUrl = canvas.toDataURL('image/png');
 
-    const scaled = await scaleToMaxDimension(dataUrl, 1000);
+    const scaled = await resizeImage(dataUrl, { maxDimension: 1000 });
     const img = new Image();
     await new Promise<void>((resolve, reject) => {
       img.onload = () => resolve();
@@ -39,7 +39,26 @@ describe('scaleToMaxDimension', () => {
     ctx.fillRect(0, 0, 800, 600);
     const dataUrl = canvas.toDataURL('image/png');
 
-    const scaled = await scaleToMaxDimension(dataUrl, 1000);
+    const scaled = await resizeImage(dataUrl, { maxDimension: 1000 });
     expect(scaled).toBe(dataUrl);
   });
+
+  test('downscales image by scale factor', async () => {
+    const canvas = createCanvas(1200, 600);
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 1200, 600);
+    const dataUrl = canvas.toDataURL('image/png');
+
+    const scaled = await resizeImage(dataUrl, { scale: 0.5 });
+    const img = new Image();
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = (err) => reject(err);
+      img.src = scaled;
+    });
+    expect(img.width).toBe(600);
+    expect(img.height).toBe(300);
+  });
 });
+


### PR DESCRIPTION
## Summary
- add resizeImage helper that handles max dimension or scale with optional background color
- use resizeImage throughout image processing flow and drop legacy helpers
- document new helper and cover with tests

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc. in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c48ec7e0648323b362407276c48a1a