### PR TITLE
feat: check URL reachability with HEAD requests

### DIFF
--- a/src/utils/networkUtils.ts
+++ b/src/utils/networkUtils.ts
@@ -54,14 +54,19 @@ async function getLocalIPs(): Promise<string[]> {
  * @param url The URL to test
  */
 async function isReachable(url: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 1000);
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 1000);
-    await fetch(url, { mode: 'no-cors', signal: controller.signal });
-    clearTimeout(timeout);
-    return true;
+    const response = await fetch(url, {
+      method: 'HEAD',
+      mode: 'cors',
+      signal: controller.signal
+    });
+    return response.ok;
   } catch {
     return false;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 


### PR DESCRIPTION
## Summary
- use `HEAD` requests with CORS in network reachability checks
- treat non-2xx and CORS failures as unreachable with timeout safeguard

## Testing
- `npm test`
- `npm run lint` *(fails: 21 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c48ecd390c8323829d567c936978ec