### PR TITLE
Ensure initial uploads populate processing logs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -229,13 +229,15 @@ function App() {
     setFileName(getOptimizedFilename(file.name));
     setSvg(null);
     setError('');
-    
+    setProcessingLogs([]);
+
     try {
       setStatus('processing');
       const svgData = await processImageWithPotrace(
         imageData,
         potraceParams,
-        (newStatus) => setStatus(newStatus as ConversionStatus)
+        (newStatus) => setStatus(newStatus as ConversionStatus),
+        handleLogEntry
       );
       setSvg(svgData);
       setStatus('done');
@@ -244,7 +246,7 @@ function App() {
       setError(err instanceof Error ? err.message : 'Unknown error');
       setStatus('error');
     }
-  }, [potraceParams]);
+  }, [potraceParams, handleLogEntry]);
 
   // Expose the processImage function for batch processing
   const processImage = useCallback(async (imageData: string, params: TracingParams) => {


### PR DESCRIPTION
## Summary
- clear the processing log state when a new image is selected so each trace starts fresh
- pass the log callback into the initial Potrace run to capture log entries on the first conversion

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e417c4a4fc8323ade98b05c662967c